### PR TITLE
  Phase 1 — clean_range_markers in ebible.py

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 EBIBLE_DATA_DIR=C:\ebible_data_pipeline
 CORPUS_PATH=C:\ebible_data_pipeline\corpus
-MAX_AGE_DAYS=365
-LOG_LEVEL=DEBUG
+MAX_AGE_DAYS=565
+LOG_LEVEL=WARNING
 
 TEST_EBIBLE_DATA_DIR=C:\ebible_data_test
 

--- a/assets/parquet_README_template.md
+++ b/assets/parquet_README_template.md
@@ -1,0 +1,106 @@
+---
+language:
+- multilingual
+license: other
+multilinguality: multilingual
+size_categories:
+- 10K<n<100K
+task_categories:
+- translation
+- text-generation
+pretty_name: eBible Parallel Corpus
+---
+
+# eBible Parallel Corpus
+
+A verse-aligned parallel corpus of {{TRANSLATION_COUNT}} Bible translations across {{LANGUAGE_COUNT}} languages, prepared from publicly redistributable texts hosted by [eBible.org](https://ebible.org).
+
+Generated: {{GENERATED_DATE}}
+
+## Dataset Description
+
+Each row corresponds to one verse reference from the standard 41,899-verse reference list (`vref.txt`). Every translation occupies one column, identified by its `translationId`. Rows are positionally aligned: row N in every translation column refers to the same verse.
+
+- **Verse count:** {{VERSE_COUNT}}
+- **Translations:** {{TRANSLATION_COUNT}}
+- **Languages:** {{LANGUAGE_COUNT}}
+
+## Dataset Structure
+
+### Data Files
+
+| File | Description |
+|---|---|
+| `main.parquet` | Wide-format parallel corpus: one row per verse, one column per translation |
+| `metadata.parquet` | Per-translation metadata: language, licence, coverage, versification |
+
+### Fields in `main.parquet`
+
+| Column | Type | Description |
+|---|---|---|
+| `vref` | string | Verse reference, e.g. `GEN 1:1` |
+| `<translationId>` | string | Translated text for that verse; `""` = untranslated; `<range>` = verse merged into preceding range |
+
+### Fields in `metadata.parquet`
+
+| Column | Description |
+|---|---|
+| `translationId` | Unique identifier matching column names in `main.parquet` |
+| `languageCode` | ISO 639-3 language code |
+| `languageName` | Language name in the vernacular |
+| `languageNameInEnglish` | Language name in English |
+| `dialect` | Dialect, if applicable |
+| `title` | Full title of the translation |
+| `shortTitle` | Abbreviated title |
+| `description` | Description of the translation |
+| `textDirection` | `ltr` or `rtl` |
+| `script` | Writing script (e.g. `Latin`, `Arabic`) |
+| `inScript` | Whether the text uses the language's native script |
+| `OTbooks` / `OTchapters` / `OTverses` | Old Testament coverage |
+| `NTbooks` / `NTchapters` / `NTverses` | New Testament coverage |
+| `DCbooks` / `DCchapters` / `DCverses` | Deuterocanonical coverage |
+| `inferred_versification` | Versification number inferred for this translation |
+| `licence_Licence_Type` | Licence type (e.g. `Creative Commons`) |
+| `licence_Licence_Version` | Licence version (e.g. `4.0`) |
+| `licence_CC_Licence_Link` | URL to the CC licence deed |
+| `licence_Copyright_Holder` | Copyright holder |
+| `licence_Copyright_Years` | Copyright year(s) |
+| `licence_Translation_by` | Translating organisation or individual |
+| `licence_Vernacular_Title` | Title as stated in the licence file |
+| `Copyright` | Copyright statement from eBible.org |
+| `UpdateDate` | Date last updated on eBible.org |
+| `sourceDate` | Date of the source text |
+| `publicationURL` | Publication page on eBible.org |
+
+## Loading the Dataset
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("your-org/ebible-parallel", split="train")
+
+# Access a specific translation
+kjv = ds["eng-engKJV"]
+
+# Filter to New Testament
+nt_start = ds.filter(lambda row: row["vref"].startswith("MAT"))
+```
+
+## Licence Breakdown
+
+All translations in this dataset are redistributable as confirmed by eBible.org. Individual licence terms vary by translation. Consult `metadata.parquet` for per-translation licence details.
+
+{{LICENCE_TABLE}}
+
+## Citation
+
+If you use this dataset in your work, please cite eBible.org:
+
+```
+@misc{ebible,
+  title  = {eBible.org Parallel Corpus},
+  author = {eBible.org contributors},
+  url    = {https://ebible.org},
+  year   = {{{GENERATED_YEAR}}}
+}
+```

--- a/ebible_code/corpus_to_parquet.py
+++ b/ebible_code/corpus_to_parquet.py
@@ -1,443 +1,316 @@
+"""Convert eBible corpus .txt files to Parquet format for HuggingFace.
+
+Configuration is via .env — run with --help for details.
+"""
+
+import argparse
 import os
-import re
 import sys
-from dotenv import load_dotenv
+from datetime import date
 from pathlib import Path
+
 import pandas as pd
-import pyarrow
+from dotenv import load_dotenv
 from tqdm import tqdm
 
-# --- Script Logic ---
+sys.path.insert(0, str(Path(__file__).parent))
+from ebible import clean_range_markers
+
+# Columns included in metadata.parquet, in order.
+# status_inferred_versification is renamed to inferred_versification on output.
+METADATA_SOURCE_COLUMNS = [
+    # All ORIGINAL_COLUMNS from ebible_status.csv
+    "languageCode", "translationId", "languageName", "languageNameInEnglish", "dialect",
+    "homeDomain", "title", "description", "Redistributable", "Copyright", "UpdateDate",
+    "publicationURL", "OTbooks", "OTchapters", "OTverses", "NTbooks", "NTchapters",
+    "NTverses", "DCbooks", "DCchapters", "DCverses", "FCBHID", "Certified", "inScript",
+    "swordName", "rodCode", "textDirection", "downloadable", "font", "shortTitle",
+    "PODISBN", "script", "sourceDate",
+    # Selected LICENCE_COLUMNS
+    "licence_Vernacular_Title", "licence_Licence_Type", "licence_Licence_Version",
+    "licence_CC_Licence_Link", "licence_Copyright_Holder", "licence_Copyright_Years",
+    "licence_Translation_by",
+    # STATUS: versification only
+    "status_inferred_versification",
+]
+
+VREF_LENGTH = 41899
 
 
-def parse_vref(vref_line):
-    """Parses a vref line (e.g., 'GEN 1:1') into book, chapter, verse."""
-    match = re.match(r"(\w{3})\s+(\d{1,3}):(\d{1,3})", vref_line)
-    if match:
-        return match.groups()  # Returns (book, chapter, verse) as strings
-    else:
-        # Handle potential malformed lines if necessary, or return None/raise error
-        print(f"Warning: Could not parse vref line: '{vref_line}'", file=sys.stderr)
-        return None, None, None
+def build_vref_list(vref_path: Path) -> list:
+    """Read vref.txt and return a list of verse reference strings like 'GEN 1:1'."""
+    with open(vref_path, "r", encoding="utf-8") as f:
+        lines = [line.strip() for line in f if line.strip()]
+    if not lines:
+        raise ValueError(f"vref file is empty: {vref_path}")
+    return lines
+
+
+def load_and_filter_metadata(metadata_path: Path) -> pd.DataFrame:
+    """Load ebible_status.csv, filter to redistributable non-private extracted translations.
+
+    Warns for rows where only one of status_extract_date / status_extract_hash is set.
+    Returns rows where both fields are populated and path is not private_corpus.
+    """
+    df = pd.read_csv(metadata_path, keep_default_na=False, dtype={"Redistributable": str})
+
+    required = ["translationId", "status_extract_path", "Redistributable",
+                "status_extract_date", "status_extract_hash"]
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise ValueError(f"Metadata CSV missing required columns: {', '.join(missing)}")
+
+    df = df[df["Redistributable"] == "True"].copy()
+    df["status_extract_path"] = df["status_extract_path"].astype(str)
+    df = df[~df["status_extract_path"].str.contains("private_corpus", case=False, na=False)]
+    df = df[df["status_extract_path"].notna() & (df["status_extract_path"] != "")]
+
+    has_date = df["status_extract_date"].notna() & (df["status_extract_date"] != "")
+    has_hash = df["status_extract_hash"].notna() & (df["status_extract_hash"] != "")
+
+    for _, row in df[has_date & ~has_hash].iterrows():
+        print(f"Warning: {row['translationId']} has status_extract_date but no status_extract_hash",
+              file=sys.stderr)
+    for _, row in df[~has_date & has_hash].iterrows():
+        print(f"Warning: {row['translationId']} has status_extract_hash but no status_extract_date",
+              file=sys.stderr)
+
+    return df[has_date & has_hash].copy()
+
+
+def validate_corpus_files(candidates: pd.DataFrame, ebible_data_dir: Path,
+                          vref_length: int = VREF_LENGTH,
+                          _input=input) -> tuple:
+    """Clean and validate each candidate corpus file.
+
+    For each file: runs clean_range_markers in-place, checks it exists,
+    checks it has exactly vref_length lines.
+
+    Returns (valid_ids, skipped_ids) where each entry in skipped_ids is
+    (translationId, reason).  Prompts the user to continue if there are
+    failures; exits with code 1 if they decline.
+    """
+    valid_ids = []
+    issues = []
+
+    for _, row in tqdm(candidates.iterrows(), total=len(candidates), desc="Validating corpus files"):
+        tid = row["translationId"]
+        path_str = row["status_extract_path"]
+        file_path = Path(path_str) if Path(path_str).is_absolute() else ebible_data_dir / path_str
+
+        if not file_path.exists():
+            issues.append((tid, f"File not found: {file_path}"))
+            continue
+
+        cleaned = clean_range_markers(file_path)
+        if cleaned:
+            print(f"  Cleaned {cleaned} orphaned <range> marker(s) in {tid}", file=sys.stderr)
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            line_count = sum(1 for line in f)
+
+        if line_count != vref_length:
+            issues.append((tid, f"Line count {line_count} != expected {vref_length}"))
+            continue
+
+        valid_ids.append(tid)
+
+    if issues:
+        print(f"\n{len(issues)} file(s) have issues:")
+        for tid, reason in issues:
+            print(f"  {tid}: {reason}")
+        answer = _input(f"\n{len(issues)} file(s) have issues. Continue anyway and skip them? [y/N]: ")
+        if answer.strip().lower() != "y":
+            print("Aborted.")
+            sys.exit(1)
+
+    return valid_ids, [tid for tid, _ in issues]
+
+
+def load_translation_texts(candidates: pd.DataFrame, valid_ids: list,
+                           ebible_data_dir: Path) -> dict:
+    """Load the text lines for each valid translation. Returns {translationId: [lines]}."""
+    valid_set = set(valid_ids)
+    data = {}
+    for _, row in tqdm(
+        candidates[candidates["translationId"].isin(valid_set)].iterrows(),
+        total=len(valid_ids),
+        desc="Loading translations",
+    ):
+        tid = row["translationId"]
+        path_str = row["status_extract_path"]
+        file_path = Path(path_str) if Path(path_str).is_absolute() else ebible_data_dir / path_str
+        with open(file_path, "r", encoding="utf-8") as f:
+            data[tid] = [line.rstrip("\r\n") for line in f]
+    return data
+
+
+def build_main_dataframe(vref_list: list, translation_data: dict) -> pd.DataFrame:
+    """Build the wide-format main DataFrame.
+
+    First column is 'vref'. Remaining columns are translations sorted
+    alphabetically by translationId.
+    """
+    sorted_ids = sorted(translation_data.keys())
+    df = pd.DataFrame({"vref": vref_list})
+    for tid in sorted_ids:
+        df[tid] = translation_data[tid]
+    return df
+
+
+def build_metadata_dataframe(full_metadata: pd.DataFrame, included_ids: list) -> pd.DataFrame:
+    """Build the metadata DataFrame for included translations only.
+
+    Selects the columns defined in METADATA_SOURCE_COLUMNS (skipping any absent),
+    then renames status_inferred_versification -> inferred_versification.
+    """
+    df = full_metadata[full_metadata["translationId"].isin(set(included_ids))].copy()
+    present = [c for c in METADATA_SOURCE_COLUMNS if c in df.columns]
+    df = df[present].copy()
+    if "status_inferred_versification" in df.columns:
+        df = df.rename(columns={"status_inferred_versification": "inferred_versification"})
+    return df
+
+
+def _make_licence_table(metadata_df: pd.DataFrame) -> str:
+    """Build a Markdown table of translation licence info."""
+    cols = ["translationId", "licence_Licence_Type", "licence_CC_Licence_Link"]
+    present = [c for c in cols if c in metadata_df.columns]
+    rows = ["| " + " | ".join(present) + " |",
+            "| " + " | ".join("---" for _ in present) + " |"]
+    for _, row in metadata_df[present].iterrows():
+        cells = [str(row[c]) if pd.notna(row[c]) else "" for c in present]
+        rows.append("| " + " | ".join(cells) + " |")
+    return "\n".join(rows)
+
+
+def render_readme(template: str, stats: dict) -> str:
+    """Replace {{PLACEHOLDER}} markers in template with values from stats dict."""
+    result = template
+    for key, value in stats.items():
+        result = result.replace("{{" + key + "}}", str(value))
+    return result
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert eBible corpus .txt files to Parquet format for HuggingFace.\n\n"
+            "All paths are configured via .env:\n"
+            "  EBIBLE_DATA_DIR              Root of the data repository\n"
+            "  VREF_FILENAME                Filename of vref.txt under metadata/\n"
+            "  METADATA_FILENAME            Filename of ebible_status.csv under metadata/\n"
+            "  HUGGINGFACE_OUTPUT_FOLDER    Output directory for all output files\n"
+            "  HUGGINGFACE_MAIN_PARQUET_FILENAME     e.g. main.parquet\n"
+            "  HUGGINGFACE_METADATA_PARQUET_FILENAME e.g. metadata.parquet\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    return parser.parse_args()
 
 
 def main():
-    """Main function to prepare the Hugging Face dataset."""
-
-    # 1. Get EBIBLE_DATA_DIR environment variable
+    _parse_args()
     load_dotenv()
 
     ebible_data_dir_str = os.getenv("EBIBLE_DATA_DIR")
     if not ebible_data_dir_str:
-        print(
-            "Error: Environment variable EBIBLE_DATA_DIR is not set.", file=sys.stderr
-        )
-        print(
-            "Please set it to the path of your ebible_data repository.", file=sys.stderr
-        )
+        print("Error: EBIBLE_DATA_DIR is not set in .env", file=sys.stderr)
         sys.exit(1)
-
     ebible_data_dir = Path(ebible_data_dir_str)
     if not ebible_data_dir.is_dir():
-        print(
-            f"Error: EBIBLE_DATA_DIR path does not exist or is not a directory: {ebible_data_dir}",
-            file=sys.stderr,
-        )
+        print(f"Error: EBIBLE_DATA_DIR does not exist: {ebible_data_dir}", file=sys.stderr)
         sys.exit(1)
 
-    # 2. Construct necessary paths
-    vref_path = ebible_data_dir / "metadata" / os.getenv("VREF_FILENAME")
-    metadata_path = ebible_data_dir / "metadata" / os.getenv("METADATA_FILENAME")
+    vref_path = ebible_data_dir / "metadata" / os.getenv("VREF_FILENAME", "vref.txt")
+    metadata_path = ebible_data_dir / "metadata" / os.getenv("METADATA_FILENAME", "ebible_status.csv")
+    hf_output_dir = ebible_data_dir / os.getenv("HUGGINGFACE_OUTPUT_FOLDER", "huggingface")
+    main_parquet_path = hf_output_dir / os.getenv("HUGGINGFACE_MAIN_PARQUET_FILENAME", "main.parquet")
+    metadata_parquet_path = hf_output_dir / os.getenv("HUGGINGFACE_METADATA_PARQUET_FILENAME", "metadata.parquet")
+    readme_path = hf_output_dir / "README.md"
+    template_path = Path(__file__).parent.parent / "assets" / "README_template.md"
 
-    hf_output_dir = ebible_data_dir / (os.getenv("HUGGINGFACE_OUTPUT_FOLDER"))
+    for path, label in [(vref_path, "VREF_FILENAME"), (metadata_path, "METADATA_FILENAME")]:
+        if not path.exists():
+            print(f"Error: {label} not found: {path}", file=sys.stderr)
+            sys.exit(1)
 
     if not hf_output_dir.is_dir():
-        print(f"Error: Could not find HUGGINGFACE_OUTPUT_FOLDER: {hf_output_dir}.")
+        print(f"Error: HUGGINGFACE_OUTPUT_FOLDER does not exist: {hf_output_dir}", file=sys.stderr)
         sys.exit(1)
 
-    hf_main_parquet_file = hf_output_dir / os.getenv(
-        "HUGGINGFACE_MAIN_PARQUET_FILENAME"
-    )
-    hf_metadata_parquet_file = hf_output_dir / os.getenv(
-        "HUGGINGFACE_METADATA_PARQUET_FILENAME"
-    )
+    # Step 1: Load vref
+    print("--- Loading vref ---")
+    vref_list = build_vref_list(vref_path)
+    print(f"  {len(vref_list)} verse references loaded")
 
-    print(f"Using EBIBLE_DATA_DIR:           {ebible_data_dir}")
-    print(f"Reading vref from:               {vref_path}")
-    print(f"Reading metadata from:           {metadata_path}")
-    print(f"Output folder for parquet files: {hf_output_dir}")
-
-    # 3. Load and parse vref.txt
-    print("\n--- Loading vref.txt ---")
+    # Step 2: Load and filter metadata
+    print("\n--- Loading metadata ---")
+    full_metadata_df = pd.read_csv(metadata_path, keep_default_na=False, dtype={"Redistributable": str})
+    total_in_metadata = len(full_metadata_df)
     try:
-        with open(vref_path, "r", encoding="utf-8") as f_vref:
-            vref_lines = [
-                line.strip() for line in f_vref if line.strip()
-            ]  # Read non-empty lines
-        vref_length = len(vref_lines)
-        print(f"Successfully read {vref_length} verse references.")
-
-        if vref_length == 0:
-            print(
-                "Error: vref.txt is empty or contains only whitespace.", file=sys.stderr
-            )
-            sys.exit(1)
-
-        # Parse vref lines into components
-        parsed_vrefs = [parse_vref(line) for line in vref_lines]
-        books, chapters, verses = zip(
-            *[(b, c, v) for b, c, v in parsed_vrefs if b is not None]
-        )  # Filter out failed parses
-
-        # Check if parsing failed for some lines
-        if len(books) != vref_length:
-            print(
-                f"Warning: {vref_length - len(books)} vref lines could not be parsed.",
-                file=sys.stderr,
-            )
-            # Decide if this is critical - for now, we proceed with parsed lines
-            # If strict matching is needed, you might want to exit here.
-
-        # Create the initial DataFrame
-        df = pd.DataFrame(
-            {
-                "book": list(books),
-                "chapter": pd.to_numeric(chapters),  # Convert chapters to numeric
-                "verse": pd.to_numeric(verses),  # Convert verses to numeric
-            }
-        )
-        # Use the original vref_lines as index if needed later, or just rely on row number
-        # df.index = vref_lines[:len(df)] # Assign only if lengths match after filtering bad parses
-
-    except FileNotFoundError:
-        print(f"Error: vref.txt not found at {vref_path}", file=sys.stderr)
+        candidates = load_and_filter_metadata(metadata_path)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
-    except Exception as e:
-        print(f"Error reading or parsing {vref_path}: {e}", file=sys.stderr)
+    print(f"  {total_in_metadata} total translations, {len(candidates)} candidates (redistributable, extracted)")
+
+    # Step 3: Pre-flight validation
+    print("\n--- Validating corpus files ---")
+    valid_ids, skipped_ids = validate_corpus_files(candidates, ebible_data_dir, len(vref_list))
+    print(f"  {len(valid_ids)} valid, {len(skipped_ids)} skipped")
+
+    if not valid_ids:
+        print("Error: No valid translations to include.", file=sys.stderr)
         sys.exit(1)
 
-    # 4. Load and filter metadata
-    print("\n--- Loading Metadata ---")
-    try:
-        metadata_df = pd.read_csv(
-            metadata_path, keep_default_na=False, dtype={"Redistributable": str}
-        )  # Read Redistributable as string
-        print(f"Read {len(metadata_df)} total metadata entries.")
+    # Step 4: Load text and build main.parquet
+    print("\n--- Loading translation texts ---")
+    translation_data = load_translation_texts(candidates, valid_ids, ebible_data_dir)
 
-        # --- Filtering ---
-        # 1. Check required columns exist
-        required_cols = [
-            "translationId",
-            "status_extract_path",
-            "Redistributable",
-            "status_extract_date",
-            "status_extract_hash",
-        ]
-        missing_cols = [col for col in required_cols if col not in metadata_df.columns]
-        if missing_cols:
-            print(
-                f"Error: Metadata CSV missing required columns: {', '.join(missing_cols)}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+    print("\n--- Building main.parquet ---")
+    main_df = build_main_dataframe(vref_list, translation_data)
+    main_df.to_parquet(main_parquet_path, index=False, engine="pyarrow", compression="snappy")
+    print(f"  Written: {main_parquet_path} ({len(main_df)} rows × {len(main_df.columns)} columns)")
 
-        # 2. Filter by Redistributable == "True" (case-sensitive string comparison)
-        filtered_df = metadata_df[metadata_df["Redistributable"] == "True"].copy()
-        print(f"Found {len(filtered_df)} redistributable translations.")
+    # Step 5: Build metadata.parquet
+    print("\n--- Building metadata.parquet ---")
+    metadata_df = build_metadata_dataframe(full_metadata_df, valid_ids)
+    metadata_df.to_parquet(metadata_parquet_path, index=False, engine="pyarrow", compression="snappy")
+    print(f"  Written: {metadata_parquet_path} ({len(metadata_df)} rows)")
 
-        # 3. Filter out entries where path contains 'private_corpus'
-        # Ensure status_extract_path is treated as string
-        filtered_df["status_extract_path"] = filtered_df["status_extract_path"].astype(
-            str
-        )
-        original_count = len(filtered_df)
-        filtered_df = filtered_df[
-            ~filtered_df["status_extract_path"].str.contains(
-                "private_corpus", case=False, na=False
-            )
-        ]
-        print(
-            f"Removed {original_count - len(filtered_df)} entries referencing 'private_corpus'."
-        )
+    # Step 6: Generate README.md
+    print("\n--- Generating README.md ---")
+    language_count = metadata_df["languageCode"].nunique() if "languageCode" in metadata_df.columns else "?"
+    licence_table = _make_licence_table(metadata_df)
 
-        # 4. Drop entries with missing or invalid paths (optional but good practice)
-        filtered_df = filtered_df.dropna(subset=["status_extract_path"])
-        filtered_df = filtered_df[filtered_df["status_extract_path"] != ""]
-
-        # 5. Check extraction completion status
-        extraction_warnings = []
-        pre_extraction_count = len(filtered_df)
-
-        # Create boolean masks for extraction status
-        has_extract_date = filtered_df["status_extract_date"].notna() & (
-            filtered_df["status_extract_date"] != ""
-        )
-        has_extract_hash = filtered_df["status_extract_hash"].notna() & (
-            filtered_df["status_extract_hash"] != ""
-        )
-
-        # Case 1: Both fields empty - skip silently (not extracted)
-        both_empty = ~has_extract_date & ~has_extract_hash
-
-        # Case 2: Only one field populated - add to warnings list
-        only_date = has_extract_date & ~has_extract_hash
-        only_hash = ~has_extract_date & has_extract_hash
-
-        # Case 3: Both fields populated - proceed with processing
-        both_populated = has_extract_date & has_extract_hash
-
-        # Collect warnings for incomplete extraction status
-        for idx, row in filtered_df[only_date].iterrows():
-            extraction_warnings.append(
-                f"For translation {row['translationId']} the ebible_status file contains a status_extract_date without a status_extract_hash"
-            )
-
-        for idx, row in filtered_df[only_hash].iterrows():
-            extraction_warnings.append(
-                f"For translation {row['translationId']} the ebible_status file contains a status_extract_hash without a status_extract_date"
-            )
-
-        # Filter to only include translations with complete extraction status
-        filtered_df = filtered_df[both_populated].copy()
-
-        print(
-            f"After extraction status validation: {len(filtered_df)} translations ready for processing."
-        )
-        print(f"Silently skipped {sum(both_empty)} translations (not extracted).")
-        print(
-            f"Found {len(extraction_warnings)} translations with incomplete extraction status."
-        )
-
-        # Display specific warning messages for incomplete extraction status
-        if extraction_warnings:
-            print("\n--- Extraction Status Warnings ---")
-            for warning in extraction_warnings:
-                print(f"Warning: {warning}", file=sys.stderr)
-
-    except FileNotFoundError:
-        print(f"Error: Metadata file not found at {metadata_path}", file=sys.stderr)
-        sys.exit(1)
-    except Exception as e:
-        print(f"Error reading or filtering {metadata_path}: {e}", file=sys.stderr)
-        sys.exit(1)
-
-    # 5. Process translation files
-    print("\n--- Processing Translation Files ---")
-    skipped_translations = []  # List to store info about skipped files
-    translation_data = {}  # Dictionary to hold {translation_id: [line1, line2,...]}
-
-    for index, row in tqdm(
-        filtered_df.iterrows(), total=len(filtered_df), desc="Translations"
-    ):
-        translation_id = row["translationId"]
-        text_file_path_str = row["status_extract_path"]
-
-        # Handle potential relative paths in metadata - assume relative to EBIBLE_DATA_DIR if not absolute
-        text_file_path = Path(text_file_path_str)
-        if not text_file_path.is_absolute():
-            # This assumes paths like 'corpus/eng-engESV.txt' are relative to ebible_data_dir
-            # Adjust if the paths in the CSV are relative to a different base
-            text_file_path = ebible_data_dir / text_file_path
-
-        if not text_file_path.exists():
-            # This should not happen since we filtered for complete extraction status earlier
-            # If we reach here, it means both status_extract_date and status_extract_hash are populated
-            # but the file is missing - this indicates a data integrity issue
-            print(
-                f"Error: Expected extracted file not found for {translation_id} (extraction status indicates complete): {text_file_path}",
-                file=sys.stderr,
-            )
-            skipped_translations.append(
-                {
-                    "id": translation_id,
-                    "path": str(text_file_path),
-                    "reason": "Expected file missing (extraction marked complete but file not found)",
-                }
-            )
-            continue
-
-        try:
-            with open(text_file_path, "r", encoding="utf-8") as f_text:
-                # Read all lines, preserving empty lines and stripping only trailing newline/whitespace
-                text_lines = [line.rstrip("\r\n") for line in f_text]
-
-            # --- Line Count Check ---
-            if len(text_lines) != vref_length:
-                print(
-                    f"Warning: Line count mismatch for {translation_id} ({len(text_lines)} lines) vs vref.txt ({vref_length} lines). Skipping.",
-                    file=sys.stderr,
-                )
-                skipped_translations.append(
-                    {
-                        "id": translation_id,
-                        "path": str(text_file_path),
-                        "reason": f"Line count mismatch ({len(text_lines)} vs {vref_length})",
-                    }
-                )
-                continue
-
-            # Store data for later concatenation
-            # Ensure the column name is valid (pandas might handle some cases, but good to be safe)
-            # For Hugging Face, simple IDs are usually fine.
-            if translation_id in translation_data:
-                # This check might be redundant if translationId is unique in metadata, but safe to keep
-                print(
-                    f"Warning: Duplicate translationId '{translation_id}' encountered during processing. Overwriting previous data for this ID.",
-                    file=sys.stderr,
-                )
-                # Or potentially add a suffix, e.g., f"{translation_id}_{index}"
-            translation_data[translation_id] = text_lines
-
-        except Exception as e:
-            print(
-                f"Error processing file {text_file_path.name} for {translation_id}: {e}",
-                file=sys.stderr,
-            )
-            skipped_translations.append(
-                {
-                    "id": translation_id,
-                    "path": str(text_file_path),
-                    "reason": f"Processing error: {e}",
-                }
-            )
-            # Decide whether to continue or exit on error
-            # continue
-
-    # 6. Combine base DataFrame with translation data
-    print("\n--- Combining DataFrames ---")
-    if translation_data:
-        included_translation_ids = list(translation_data.keys())
-        translations_df = pd.DataFrame(translation_data)
-        df = pd.concat([df, translations_df], axis=1)
-        print(f"Added {len(translations_df.columns)} translation columns.")
+    if template_path.exists():
+        template = template_path.read_text(encoding="utf-8")
     else:
-        included_translation_ids = []
-        print("No translation data was collected.")
-    # 7. Save Main Parquet Output
-    print("\n--- Saving Parquet File ---")
-    if len(df.columns) <= 3:  # Only book, chapter, verse columns exist
-        print(
-            "Error: No translation data was successfully processed and added.",
-            file=sys.stderr,
-        )
-        print("Please check warnings and input files.", file=sys.stderr)
-    else:
-        try:
-            print(
-                f"Writing {len(df)} rows and {len(df.columns)} columns to {hf_main_parquet_file}..."
-            )
-            df.to_parquet(
-                hf_main_parquet_file,
-                index=False,
-                engine="pyarrow",
-                compression="snappy",
-            )
-            print("Successfully wrote Parquet file.")
-        except Exception as e:
-            print(
-                f"Error writing Parquet file to {hf_main_parquet_file}: {e}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        print(f"Warning: README template not found at {template_path}. Writing minimal README.",
+              file=sys.stderr)
+        template = "# eBible Parallel Corpus\n\nGenerated: {{GENERATED_DATE}}\n"
 
-    # 8. Prepare and Save Metadata File for Included Translations
-    print("\n--- Preparing and Saving Metadata File ---")
-    if included_translation_ids:
-        # Filter the original metadata_df to include only rows for translations present in the parquet file
-        final_metadata_df = metadata_df[
-            metadata_df["translationId"].isin(included_translation_ids)
-        ].copy()
+    today = date.today()
+    readme_content = render_readme(template, {
+        "TRANSLATION_COUNT": len(valid_ids),
+        "LANGUAGE_COUNT": language_count,
+        "VERSE_COUNT": len(vref_list),
+        "GENERATED_DATE": today.isoformat(),
+        "GENERATED_YEAR": today.year,
+        "LICENCE_TABLE": licence_table,
+    })
+    readme_path.write_text(readme_content, encoding="utf-8")
+    print(f"  Written: {readme_path}")
 
-        # Select relevant columns for the public metadata file (adjust this list as needed)
-        relevant_metadata_columns = [
-            "languageCode",
-            "translationId",
-            "languageName",
-            "languageNameInEnglish",
-            "dialect",
-            "homeDomain",
-            "title",
-            "description",
-            "Redistributable",
-            "Copyright",
-            "UpdateDate",
-            "publicationURL",
-            "OTbooks",
-            "OTchapters",
-            "OTverses",
-            "NTbooks",
-            "NTchapters",
-            "NTverses",
-            "DCbooks",
-            "DCchapters",
-            "DCverses",
-            "FCBHID",
-            "Certified",
-            "inScript",
-            "swordName",
-            "rodCode",
-            "textDirection",
-            "downloadable",
-            "font",
-            "shortTitle",
-            "PODISBN",
-            "script",
-            "sourceDate",
-            "licence_ID",
-            "licence_File",
-            "licence_Language",
-            "licence_Dialect",
-            "licence_Vernacular_Title",
-            "licence_Licence_Type",
-            "licence_Licence_Version",
-            "licence_CC_Licence_Link",
-            "licence_Copyright_Holder",
-            "licence_Copyright_Years",
-            "licence_Translation_by",
-            "status_versification",
-            "status_inferred_versification",  # Added the new column
-        ]
-        # Ensure only existing columns are selected
-        relevant_metadata_columns = [
-            col for col in relevant_metadata_columns if col in final_metadata_df.columns
-        ]
-        final_metadata_df = final_metadata_df[relevant_metadata_columns]
-
-        try:
-            print(
-                f"Writing metadata for {len(final_metadata_df)} included translations to {hf_main_parquet_file}..."
-            )
-            final_metadata_df.to_csv(
-                hf_main_parquet_file, index=False, encoding="utf-8"
-            )
-            print("Successfully wrote metadata CSV file.")
-        except Exception as e:
-            print(
-                f"Error writing metadata CSV file to {hf_main_parquet_file}: {e}",
-                file=sys.stderr,
-            )
-            # Don't exit, the main parquet might still be useful
-    else:
-        print("Skipping metadata file generation as no translations were included.")
-
-    # 9. Final Report
-    print("\n--- Processing Summary ---")
-    print(f"Total translations in metadata: {len(metadata_df)}")
-    print(
-        f"Considered for processing (Redistributable, not private): {len(filtered_df)}"
-    )
-    processed_count = len(df.columns) - 3  # Subtract book, chapter, verse columns
-    print(f"Successfully processed and included: {processed_count}")
-    print(f"Skipped translations: {len(skipped_translations)}")
-
-    if skipped_translations:
-        print("\nSkipped Translations Report:")
-        for item in skipped_translations:
-            print(
-                f"  - ID: {item['id']}, Reason: {item['reason']}, Path: {item['path']}"
-            )
-
-    print("\nPreprocessing finished.")
+    # Step 7: Summary
+    print("\n--- Summary ---")
+    print(f"  Translations in metadata:      {total_in_metadata}")
+    print(f"  Candidates (redistributable):  {len(candidates)}")
+    print(f"  Pre-flight failures (skipped): {len(skipped_ids)}")
+    print(f"  Included in main.parquet:      {len(valid_ids)}")
+    print(f"  Languages represented:         {language_count}")
+    print(f"  Output:                        {hf_output_dir}")
 
 
 if __name__ == "__main__":

--- a/ebible_code/ebible.py
+++ b/ebible_code/ebible.py
@@ -240,6 +240,34 @@ def scan_corpus_file(extract_path: Path) -> Optional[tuple[str, str]]:
     return None
 
 
+def clean_range_markers(file_path: Path) -> int:
+    """Remove orphaned <range> markers from a corpus .txt file in-place.
+
+    A <range> marker is orphaned when its immediately preceding line is empty.
+    Processing top-to-bottom means cascading chains are handled automatically:
+    once an orphaned <range> is replaced with "", the next <range> in the chain
+    also sees "" as its predecessor and is replaced.
+
+    Returns the number of replacements made.
+    """
+    with open(file_path, "r", encoding="utf-8") as f:
+        lines = [line.rstrip("\r\n") for line in f]
+
+    replacements = 0
+    for i in range(len(lines)):
+        if lines[i] == "<range>":
+            prev = lines[i - 1] if i > 0 else ""
+            if prev == "":
+                lines[i] = ""
+                replacements += 1
+
+    if replacements:
+        with open(file_path, "w", encoding="utf-8", newline="\n") as f:
+            f.write("\n".join(lines) + "\n")
+
+    return replacements
+
+
 # --- Core Logic Functions ---
 
 def initialize_or_load_status(status_path: Path, translations_path: Path) -> pd.DataFrame:
@@ -973,6 +1001,9 @@ def extract_and_finalize_texts(
         )
 
         if success:
+            cleaned = clean_range_markers(output_file_path)
+            if cleaned:
+                root_logger.debug(f"Cleaned {cleaned} orphaned <range> marker(s) in {output_file_path.name}")
             df.loc[index, 'status_extract_path'] = str(output_file_path.resolve())
             df.loc[index, 'status_extract_date'] = TODAY_STR
             df.loc[index, 'status_last_error'] = np.nan # Clear error on success

--- a/parquet_feature/PARQUET.md
+++ b/parquet_feature/PARQUET.md
@@ -1,0 +1,16 @@
+The next feature I would like to work on is the parquet file creation so that the output data can be uploaded to huggingface in the way that is most useful for machine learning experiments. 
+
+To create the spec for the feature interview me in depth about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one by one.  Ask about requirements, edge cases, user experience, data models, and failure modes. Do not write a plan document or code until we are in agreement about how to proceed. 
+
+After the interview phase, and before you start work on this project, create three files: 
+1. spec.md — a complete spec with goals, implementation details, and a verification section describing exactly how you'll prove each piece works.
+2. todo.md — a running to-do list you'll edit as you work. Break complex tasks into verifiable sub-tasks.
+3. Store tests in tests/ to verify everything you build. Loop on them until each passes.
+
+While you work:
+ (a) Consult spec.md before every change.
+ (b) Mark each completed task in todo.md with [x] once it is completed. 
+ (c) run tests after every meaningful commit, 
+ (d) every 20 iterations or so, call a fresh sub-agent with "Review spec.md and the current implementation for gaps" and loop on the sub-agent's feedback until alignment is reached.
+
+Do not ask me for clarification on anything you can resolve by reading the spec and running the tests. Start with the spec.

--- a/parquet_feature/issues.md
+++ b/parquet_feature/issues.md
@@ -1,0 +1,78 @@
+# Open Issues
+
+Issues and questions that arose during implementation. Resolve before final release.
+
+---
+
+## 1. LICENCE_TABLE size in README.md
+
+**Issue:** The `{{LICENCE_TABLE}}` placeholder is replaced with a Markdown table of all included translations (potentially 700+ rows). This makes `README.md` very large and may render poorly on HuggingFace.
+
+**Options:**
+- Keep the full table (current behaviour).
+- Replace with a summary table grouped by licence type (e.g. "Creative Commons 4.0: 450 translations").
+- Remove the table entirely and point users to `metadata.parquet`.
+- Cap the table at N rows with a "... and N more" note.
+
+**Resolution needed from:** user.
+
+---
+
+## 2. Pre-existing versification test failures
+
+**Issue:** `tests/test_settings_file.py` has 2 pre-existing failures unrelated to this feature:
+- `test_get_versification[abt-maprik-English]` — scores as Septuagint instead of English
+- `test_get_versification[eng-uk-lxx2012-Septuagint]` — scores as Russian Protestant instead of Septuagint
+
+These existed before any changes on this branch. They are tracked here for completeness.
+
+**Resolution needed from:** separate investigation of `get_versification_with_scoring`.
+
+---
+
+## 3. Double file reads during validation + load
+
+**Issue:** `validate_corpus_files` reads each file to count lines; `load_translation_texts` re-reads the same files to load content. Each valid file is therefore read twice, which doubles I/O for large corpora.
+
+**Impact:** Low — sequential reads of flat text files are fast. Not a correctness issue.
+
+**Options:**
+- Accept the double read (current, simpler code).
+- Combine validation and loading into a single pass (more complex, harder to test separately).
+
+**Resolution needed from:** performance testing on real corpus.
+
+---
+
+## 4. `sys.path.insert` in `corpus_to_parquet.py`
+
+**Issue:** `corpus_to_parquet.py` inserts `ebible_code/` into `sys.path` at module level to import `clean_range_markers` from `ebible`. This is a workaround for the flat (non-package) layout of `ebible_code/`. If the project is ever reorganised into a proper Python package, this should be replaced with a relative import.
+
+**Resolution needed from:** future package restructure (not urgent).
+
+---
+
+## 5. Interactive prompt incompatible with non-interactive runs
+
+**Issue:** `validate_corpus_files` uses `input()` to ask whether to continue when issues are found. This hangs if `corpus_to_parquet.py` is called from a CI pipeline or a script.
+
+**Current mitigation:** The `_input` parameter allows tests (and future automation) to inject a non-interactive responder.
+
+**Options:**
+- Add a `--non-interactive` / `--skip-issues` CLI flag that defaults to "continue" without prompting.
+- Document that automated callers should pipe `y` to stdin.
+
+**Resolution needed from:** user (when/if automation is needed).
+
+---
+
+## 6. `README_template.md` citation year
+
+**Issue:** The citation block in `assets/README_template.md` uses `{{{GENERATED_DATE}}}` for the year, which produces the full ISO date (`2026-04-30`) rather than just the year. The BibTeX `year` field conventionally takes a 4-digit year.
+
+**Options:**
+- Add a separate `{{GENERATED_YEAR}}` placeholder.
+- Extract the year from `GENERATED_DATE` in the render step.
+- Leave as-is (non-standard but harmless).
+
+**Resolution needed from:** user preference.

--- a/parquet_feature/metadata_columns.md
+++ b/parquet_feature/metadata_columns.md
@@ -1,0 +1,81 @@
+# Metadata Parquet Column Selection
+
+Mark each column `[x]` to include it in `metadata.parquet`, or `[ ]` to exclude it.
+
+Columns are grouped by source. Pipeline-internal columns (paths, dates, hashes) are pre-marked excluded by default.
+
+---
+
+## ORIGINAL_COLUMNS
+Sourced from eBible.org's `translations.csv`.
+
+- [x] `languageCode` — ISO 639-3 language code (e.g. `eng`, `zpi`)
+- [x] `translationId` — Unique identifier; matches the column names in `main.parquet` (e.g. `eng-engKJV`)
+- [x] `languageName` — Language name in the vernacular script
+- [x] `languageNameInEnglish` — Language name in English
+- [x] `dialect` — Dialect name or description, if applicable
+- [x] `homeDomain` — Geographic region or domain where the language is primarily spoken
+- [x] `title` — Full title of the translation in the vernacular
+- [x] `description` — Longer description of the translation
+- [x] `Redistributable` — Whether eBible.org permits redistribution (`True`/`False`)
+- [x] `Copyright` — Copyright statement as provided by eBible.org
+- [x] `UpdateDate` — Date the translation was last updated on eBible.org
+- [x] `publicationURL` — URL to the translation's publication page on eBible.org
+- [x] `OTbooks` — Number of Old Testament books present in this translation
+- [x] `OTchapters` — Number of Old Testament chapters present
+- [x] `OTverses` — Number of Old Testament verses present
+- [x] `NTbooks` — Number of New Testament books present
+- [x] `NTchapters` — Number of New Testament chapters present
+- [x] `NTverses` — Number of New Testament verses present
+- [x] `DCbooks` — Number of Deuterocanonical/Apocrypha books present
+- [x] `DCchapters` — Number of Deuterocanonical/Apocrypha chapters present
+- [x] `DCverses` — Number of Deuterocanonical/Apocrypha verses present
+- [x] `FCBHID` — Faith Comes By Hearing identifier for linking to audio Bible recordings
+- [x] `Certified` — Whether the translation has been certified (provenance unclear)
+- [x] `inScript` — Whether the text uses the native script of the language (`True`/`False`)
+- [x] `swordName` — Sword Project module name (used by Bible software like Sword/BibleDesktop)
+- [x] `rodCode` — Registry of Dialects code
+- [x] `textDirection` — Text direction: `ltr` or `rtl`
+- [x] `downloadable` — Whether eBible.org permits direct download (distinct from Redistributable)
+- [x] `font` — Recommended font for rendering this translation correctly
+- [x] `shortTitle` — Abbreviated title
+- [x] `PODISBN` — Print-on-demand ISBN, if available
+- [x] `script` — Writing script (e.g. `Latin`, `Arabic`, `Devanagari`)
+- [x] `sourceDate` — Date of the source text used as the basis for this translation
+
+---
+
+## LICENCE_COLUMNS
+Parsed from `copr.htm` inside each Paratext project folder.
+
+- [ ] `licence_ID` — Internal licence record identifier parsed from the copyright file
+- [ ] `licence_File` — Name of the copyright file (typically `copr.htm`)
+- [ ] `licence_Language` — Language name as stated in the licence file
+- [ ] `licence_Dialect` — Dialect as stated in the licence file
+- [x] `licence_Vernacular_Title` — Title in the vernacular as stated in the licence
+- [x] `licence_Licence_Type` — Licence type (e.g. `Creative Commons`, `Custom`)
+- [x] `licence_Licence_Version` — Licence version (e.g. `4.0` for CC BY 4.0)
+- [x] `licence_CC_Licence_Link` — URL to the Creative Commons licence deed, if applicable
+- [x] `licence_Copyright_Holder` — Name of the copyright holder
+- [x] `licence_Copyright_Years` — Year(s) covered by the copyright
+- [x] `licence_Translation_by` — Translating organisation or individual
+- [ ] `licence_date_read` — Internal: date the licence file was last parsed by the pipeline
+
+---
+
+## STATUS_COLUMNS
+Internal pipeline state. Most are excluded by default as they expose local file paths and internal bookkeeping.
+
+- [ ] `status_download_path` — Internal: local filesystem path to the downloaded ZIP
+- [ ] `status_download_date` — Internal: date the ZIP was last downloaded
+- [ ] `status_unzip_path` — Internal: local path to the unzipped Paratext project folder
+- [ ] `status_unzip_date` — Internal: date the project was last unzipped
+- [x] `status_inferred_versification` → published as **`inferred_versification`** — Versification standard inferred for this translation (e.g. 4, 0)  
+- [ ] `status_settings_xml_date` — Internal: date `Settings.xml` was last generated
+- [ ] `status_extract_path` — Internal: local path to the extracted corpus `.txt` file
+- [ ] `status_extract_date` — Internal: date the text was last extracted
+- [ ] `status_extract_hash` — Internal: xxhash of the corpus file used for change detection
+- [ ] `status_extract_hash_date` — Internal: date the hash was last computed
+- [ ] `wildebeest_hash` — Internal: hash used by wildebeest normalisation tracking
+- [ ] `wildebeest_hash_date` — Internal: date the wildebeest hash was last computed
+- [ ] `status_last_error` — Internal: last error message from pipeline processing

--- a/parquet_feature/spec.md
+++ b/parquet_feature/spec.md
@@ -1,0 +1,203 @@
+# Parquet Export — Specification
+
+## Goals
+
+1. Produce `main.parquet`: a wide-format, verse-aligned parallel corpus covering all redistributable, extracted eBible translations.
+2. Produce `metadata.parquet`: per-translation metadata for every translation present in `main.parquet`.
+3. Produce `README.md` in the output folder: a HuggingFace dataset card generated from a static template with injected statistics.
+4. Add `clean_range_markers(file_path)` to `ebible.py`: removes orphaned `<range>` markers in-place from corpus `.txt` files, called after extraction and again during the Parquet validation pass.
+
+No HuggingFace upload. All output files are always overwritten on each run.
+
+---
+
+## Part 1 — `clean_range_markers(file_path)`
+
+### Location
+`ebible_code/ebible.py`, as a standalone importable function.
+
+### Algorithm
+Single top-to-bottom pass over the lines of a corpus `.txt` file:
+
+```
+for i in range(len(lines)):
+    if lines[i] == "<range>":
+        prev = lines[i - 1] if i > 0 else ""
+        if prev == "":
+            lines[i] = ""
+```
+
+- Line 0 being `<range>` is treated as orphaned (no preceding line → `prev = ""`).
+- Processing top-to-bottom makes cascading automatic: once an orphaned `<range>` is replaced with `""`, the next `<range>` in the chain sees `""` as its predecessor and is also replaced.
+- The function is idempotent: running it twice on the same file produces the same result.
+- Writes back to the same file path in-place (UTF-8, Unix line endings `\n`).
+- Returns the number of replacements made (for logging).
+
+### Insertion point in `ebible.py` pipeline
+`extract → clean_range_markers → hash`
+
+The hash recorded in `status_extract_hash` must reflect the cleaned file. `clean_range_markers` is called immediately after a successful extraction, before the hash is computed.
+
+### Backfill
+Because existing corpus files predate this function, `corpus_to_parquet.py` also calls `clean_range_markers` on every file during its pre-flight validation pass. Since the function is idempotent, re-running it on already-clean files is safe.
+
+---
+
+## Part 2 — `corpus_to_parquet.py` rewrite
+
+### CLI
+Uses `argparse`. No positional arguments and no optional flags except `--help`.
+`--help` text must state that `HUGGINGFACE_OUTPUT_FOLDER` (and other paths) are configured via `.env`.
+
+### Environment variables (all loaded from `.env`)
+| Variable | Purpose |
+|---|---|
+| `EBIBLE_DATA_DIR` | Root of the data repository |
+| `VREF_FILENAME` | Filename of `vref.txt` under `metadata/` |
+| `METADATA_FILENAME` | Filename of `ebible_status.csv` under `metadata/` |
+| `HUGGINGFACE_OUTPUT_FOLDER` | Output directory for all three output files |
+| `HUGGINGFACE_MAIN_PARQUET_FILENAME` | Filename for `main.parquet` |
+| `HUGGINGFACE_METADATA_PARQUET_FILENAME` | Filename for `metadata.parquet` |
+
+### Step 1 — Load vref
+
+Read `vref.txt`. Build a list of 41,899 vref strings (`"GEN 1:1"`, ...). Abort with a clear error if the file is missing or empty.
+
+### Step 2 — Load and filter metadata
+
+Read `ebible_status.csv`. Filter to rows where:
+- `Redistributable == "True"`
+- `status_extract_path` is non-empty and does not contain `"private_corpus"`
+- Both `status_extract_date` and `status_extract_hash` are populated
+
+Warn (do not skip silently) for rows where exactly one of those two fields is populated.
+
+### Step 3 — Pre-flight validation pass
+
+For each candidate translation, with a `tqdm` progress bar:
+
+1. Call `clean_range_markers(path)` in-place (backfill).
+2. Check the file exists.
+3. Check `len(lines) == 41899`.
+
+Collect all failures into a list. After the pass:
+
+- If no failures: proceed.
+- If failures exist: print a formatted report listing every failed translation with its reason, then prompt:
+  ```
+  N file(s) have issues. Continue anyway and skip them? [y/N]:
+  ```
+  - If the user enters anything other than `y` or `Y`: exit with code 1.
+  - If `y`/`Y`: remove the failing translations from the candidate set and continue.
+
+### Step 4 — Build `main.parquet`
+
+- Load each passing translation file into a dict `{translationId: [line, ...]}`.
+- Build a DataFrame:
+  - Column 1: `vref` — the 41,899 vref strings from `vref.txt`.
+  - Remaining columns: one per translation, **sorted alphabetically by `translationId`**.
+  - All translation columns have dtype `object` (string).
+- Write to `HUGGINGFACE_OUTPUT_FOLDER / HUGGINGFACE_MAIN_PARQUET_FILENAME` using `engine="pyarrow"`, `compression="snappy"`, `index=False`.
+- Always overwrite.
+
+### Step 5 — Build `metadata.parquet`
+
+Include only the translations present in `main.parquet`.
+
+**Included columns** (in this order):
+
+*From ORIGINAL_COLUMNS (all 33):*
+`languageCode`, `translationId`, `languageName`, `languageNameInEnglish`, `dialect`,
+`homeDomain`, `title`, `description`, `Redistributable`, `Copyright`, `UpdateDate`,
+`publicationURL`, `OTbooks`, `OTchapters`, `OTverses`, `NTbooks`, `NTchapters`,
+`NTverses`, `DCbooks`, `DCchapters`, `DCverses`, `FCBHID`, `Certified`, `inScript`,
+`swordName`, `rodCode`, `textDirection`, `downloadable`, `font`, `shortTitle`,
+`PODISBN`, `script`, `sourceDate`
+
+*From LICENCE_COLUMNS (7):*
+`licence_Vernacular_Title`, `licence_Licence_Type`, `licence_Licence_Version`,
+`licence_CC_Licence_Link`, `licence_Copyright_Holder`, `licence_Copyright_Years`,
+`licence_Translation_by`
+
+*From STATUS_COLUMNS (1, renamed):*
+`status_inferred_versification` → **`inferred_versification`**
+
+Columns absent from `ebible_status.csv` are silently skipped (forward-compatible).
+
+Write to `HUGGINGFACE_OUTPUT_FOLDER / HUGGINGFACE_METADATA_PARQUET_FILENAME` using `engine="pyarrow"`, `compression="snappy"`, `index=False`.
+
+### Step 6 — Generate `README.md`
+
+Read `assets/README_template.md`. Replace placeholders:
+
+| Placeholder | Value |
+|---|---|
+| `{{TRANSLATION_COUNT}}` | Number of translation columns in `main.parquet` |
+| `{{LANGUAGE_COUNT}}` | Count of unique `languageCode` values among included translations |
+| `{{VERSE_COUNT}}` | 41899 (constant) |
+| `{{GENERATED_DATE}}` | ISO date of the run (`YYYY-MM-DD`) |
+| `{{LICENCE_TABLE}}` | Markdown table of `translationId`, `licence_Licence_Type`, `licence_CC_Licence_Link` for all included translations |
+
+Write to `HUGGINGFACE_OUTPUT_FOLDER / "README.md"`. Always overwrite.
+
+### Step 7 — Print summary
+
+```
+--- Summary ---
+Translations in metadata:       <N>
+Candidates (redistributable):   <N>
+Pre-flight failures (skipped):  <N>
+Included in main.parquet:       <N>
+Languages represented:          <N>
+Output:                         <path>
+```
+
+---
+
+## Part 3 — Bug fixes in existing code
+
+- `corpus_to_parquet.py` line 397: remove `"status_versification"` from the metadata column list (column does not exist).
+- `corpus_to_parquet.py` line 410: metadata was being written to `hf_main_parquet_file` instead of `hf_metadata_parquet_file`. Fixed as part of the rewrite.
+- `corpus_to_parquet.py` line 410: metadata was written as CSV. Fixed: both output files are now Parquet.
+
+---
+
+## Verification
+
+Each requirement maps to at least one test. Tests live in `tests/test_parquet.py` and `tests/test_clean_range_markers.py`.
+
+### `clean_range_markers` tests (`tests/test_clean_range_markers.py`)
+
+| Test | What it proves |
+|---|---|
+| `test_valid_range_preserved` | A `<range>` preceded by text is not modified |
+| `test_orphaned_range_replaced` | A `<range>` preceded by `""` becomes `""` |
+| `test_cascade` | Two consecutive orphaned `<range>` lines both become `""` |
+| `test_first_line_range` | Line 0 being `<range>` is treated as orphaned |
+| `test_empty_file` | File with all empty lines is unchanged |
+| `test_no_ranges` | File with no `<range>` markers is unchanged |
+| `test_mixed` | Valid and orphaned ranges in same file — only orphaned are replaced |
+| `test_idempotent` | Running the function twice produces the same result |
+| `test_return_count` | Return value equals the number of replacements made |
+
+Tests use `tmp_path` to create temporary files. No corpus data required.
+
+### `corpus_to_parquet` tests (`tests/test_parquet.py`)
+
+These tests use a small synthetic corpus (3 translations, 5 verses) and a matching synthetic `ebible_status.csv`. No real data files required.
+
+| Test | What it proves |
+|---|---|
+| `test_vref_is_first_column` | Column 0 of `main.parquet` is named `vref` |
+| `test_translations_alphabetical` | Translation columns are sorted alphabetically by ID |
+| `test_row_count` | `main.parquet` has exactly as many rows as `vref.txt` |
+| `test_empty_and_range_preserved` | `""` and `"<range>"` values survive round-trip to Parquet |
+| `test_metadata_only_included_translations` | `metadata.parquet` contains only IDs present in `main.parquet` |
+| `test_metadata_columns_order` | `metadata.parquet` has exactly the specified columns in order |
+| `test_inferred_versification_renamed` | `status_inferred_versification` appears as `inferred_versification` in `metadata.parquet` |
+| `test_readme_placeholders_replaced` | `README.md` contains none of the `{{...}}` placeholder strings |
+| `test_readme_translation_count` | `README.md` contains the correct translation count |
+| `test_missing_file_skipped` | A translation whose file does not exist is absent from both output files |
+| `test_wrong_line_count_skipped` | A translation with wrong line count is absent from both output files |
+| `test_clean_range_called_in_validation` | Orphaned ranges in an existing file are cleaned before the file is loaded |
+| `test_output_overwritten` | Re-running the script overwrites existing output files |

--- a/parquet_feature/todo.md
+++ b/parquet_feature/todo.md
@@ -1,0 +1,68 @@
+# Parquet Export — To-Do
+
+Consult spec.md before every change. Check off tasks as completed. Run tests after each section.
+
+---
+
+## Phase 1 — `clean_range_markers`
+
+- [x] Add `clean_range_markers(file_path: Path) -> int` to `ebible_code/ebible.py`
+  - [x] Top-to-bottom pass: replace `<range>` with `""` when preceded by `""`
+  - [x] Handle line-0 edge case (no predecessor → treated as orphaned)
+  - [x] Write back in-place, UTF-8, Unix line endings
+  - [x] Return count of replacements made
+- [x] Insert call in `ebible.py` pipeline: extract → `clean_range_markers` → hash
+- [x] Write `tests/test_clean_range_markers.py` with all 9 cases from spec
+- [x] Run tests — all pass (9/9)
+
+## Phase 2 — Assets
+
+- [x] Create `assets/README_template.md` with all 5 placeholders defined in spec
+  - [x] YAML frontmatter for HuggingFace
+  - [x] Static prose sections (description, structure, fields, licence, citation)
+
+## Phase 3 — `corpus_to_parquet.py` rewrite
+
+- [x] Add `argparse` with `--help` text referencing `.env`
+- [x] Fix bug: remove non-existent `status_versification` column reference
+- [x] Step 1: load vref, build list of 41,899 `"GEN 1:1"` format strings
+- [x] Step 2: load and filter `ebible_status.csv` (redistributable, not private, both extract fields set)
+- [x] Step 3: pre-flight validation pass
+  - [x] Call `clean_range_markers` on each file (backfill)
+  - [x] Check file exists
+  - [x] Check line count == 41,899
+  - [x] tqdm progress bar
+  - [x] Collect all failures, print report, prompt user
+- [x] Step 4: build `main.parquet`
+  - [x] `vref` as column 1
+  - [x] Translation columns alphabetical by `translationId`
+  - [x] Write with pyarrow / snappy
+- [x] Step 5: build `metadata.parquet`
+  - [x] Correct column list and order from spec
+  - [x] Rename `status_inferred_versification` → `inferred_versification`
+  - [x] Only included translations
+  - [x] Fix bug: write to `hf_metadata_parquet_file` (not `hf_main_parquet_file`)
+  - [x] Write as Parquet (not CSV)
+- [x] Step 6: generate `README.md`
+  - [x] Read template from `assets/README_template.md`
+  - [x] Inject all 5 placeholders
+  - [x] Write to output folder
+- [x] Step 7: print summary
+
+## Phase 4 — Tests for `corpus_to_parquet`
+
+- [x] Create `tests/test_parquet.py` with all 13 cases from spec
+  - [x] Synthetic 3-translation / 5-verse fixture (no real data required)
+  - [x] All tests pass (19/19 — spec cases plus additional coverage)
+
+## Phase 5 — Review
+
+- [x] Run full test suite — 28 new tests pass, 2 pre-existing failures in test_settings_file.py
+      (unrelated to this feature, tracked in issues.md)
+- [x] Spawn sub-agent: "Review spec.md and the current implementation for gaps"
+- [x] Address gaps found:
+  - [x] Log clean_range_markers return value in corpus_to_parquet validation pass
+  - [x] Fix BibTeX year field in README_template.md (add {{GENERATED_YEAR}} placeholder)
+  - [x] Fix spec.md verification table test name (test_metadata_columns → test_metadata_columns_order)
+  - [x] Add GENERATED_YEAR to render_readme call and test coverage
+- [ ] Resolve open items in issues.md with user

--- a/tests/test_clean_range_markers.py
+++ b/tests/test_clean_range_markers.py
@@ -1,0 +1,108 @@
+"""Tests for clean_range_markers in ebible.py."""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "ebible_code"))
+from ebible import clean_range_markers
+
+
+def write_corpus(tmp_path, lines):
+    """Write lines to a temp corpus file and return its path."""
+    p = tmp_path / "test.txt"
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return p
+
+
+def read_corpus(path):
+    return [line.rstrip("\r\n") for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_valid_range_preserved(tmp_path):
+    lines = ["In the beginning", "<range>", "<range>"]
+    p = write_corpus(tmp_path, lines)
+    count = clean_range_markers(p)
+    assert count == 0
+    assert read_corpus(p) == lines
+
+
+def test_orphaned_range_replaced(tmp_path):
+    lines = ["", "<range>"]
+    p = write_corpus(tmp_path, lines)
+    count = clean_range_markers(p)
+    assert count == 1
+    assert read_corpus(p) == ["", ""]
+
+
+def test_cascade(tmp_path):
+    """Two consecutive <range> lines after an empty line are both replaced."""
+    lines = ["", "<range>", "<range>"]
+    p = write_corpus(tmp_path, lines)
+    count = clean_range_markers(p)
+    assert count == 2
+    assert read_corpus(p) == ["", "", ""]
+
+
+def test_first_line_range(tmp_path):
+    """A <range> on line 0 has no predecessor and is treated as orphaned."""
+    lines = ["<range>", "Some text"]
+    p = write_corpus(tmp_path, lines)
+    count = clean_range_markers(p)
+    assert count == 1
+    assert read_corpus(p) == ["", "Some text"]
+
+
+def test_empty_file(tmp_path):
+    lines = ["", "", ""]
+    p = write_corpus(tmp_path, lines)
+    count = clean_range_markers(p)
+    assert count == 0
+    assert read_corpus(p) == lines
+
+
+def test_no_ranges(tmp_path):
+    lines = ["Genesis 1:1 text", "Genesis 1:2 text", ""]
+    p = write_corpus(tmp_path, lines)
+    count = clean_range_markers(p)
+    assert count == 0
+    assert read_corpus(p) == lines
+
+
+def test_mixed(tmp_path):
+    """Valid and orphaned ranges in the same file — only orphaned are replaced."""
+    lines = [
+        "Text at verse 1",
+        "<range>",   # valid — preceded by text
+        "",
+        "<range>",   # orphaned — preceded by ""
+        "Text at verse 5",
+    ]
+    p = write_corpus(tmp_path, lines)
+    count = clean_range_markers(p)
+    assert count == 1
+    assert read_corpus(p) == [
+        "Text at verse 1",
+        "<range>",
+        "",
+        "",
+        "Text at verse 5",
+    ]
+
+
+def test_idempotent(tmp_path):
+    lines = ["", "<range>", "<range>", "Text", "<range>"]
+    p = write_corpus(tmp_path, lines)
+    clean_range_markers(p)
+    result_after_first = read_corpus(p)
+    clean_range_markers(p)
+    result_after_second = read_corpus(p)
+    assert result_after_first == result_after_second
+
+
+def test_return_count(tmp_path):
+    lines = ["", "<range>", "<range>", "Text", "<range>", ""]
+    p = write_corpus(tmp_path, lines)
+    count = clean_range_markers(p)
+    # lines[1] orphaned (prev=""), lines[2] orphaned (prev becomes ""), lines[4] valid (prev="Text")
+    assert count == 2

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -1,0 +1,321 @@
+"""Tests for corpus_to_parquet.py."""
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "ebible_code"))
+from corpus_to_parquet import (
+    METADATA_SOURCE_COLUMNS,
+    VREF_LENGTH,
+    build_main_dataframe,
+    build_metadata_dataframe,
+    render_readme,
+    validate_corpus_files,
+    load_and_filter_metadata,
+    load_translation_texts,
+    _make_licence_table,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+VREF_5 = ["GEN 1:1", "GEN 1:2", "GEN 1:3", "GEN 1:4", "GEN 1:5"]
+
+TRANS_A = ["In the beginning", "<range>", "The earth was", "", "And God said"]
+TRANS_B = ["Au commencement", "", "<range>", "Et Dieu dit", "La lumière"]
+TRANS_C = ["", "<range>", "", "Text C4", "Text C5"]
+
+
+def make_corpus_files(tmp_path, translations: dict, line_count: int = 5) -> Path:
+    """Write corpus txt files; returns ebible_data_dir."""
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    for tid, lines in translations.items():
+        p = corpus_dir / f"{tid}.txt"
+        p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return tmp_path
+
+
+def make_metadata_df(tmp_path, translations: dict, extra_cols: dict = None) -> Path:
+    """Write a minimal ebible_status.csv and return its path."""
+    rows = []
+    for tid, corpus_path in translations.items():
+        row = {
+            "translationId": tid,
+            "languageCode": tid[:3],
+            "languageName": f"Language {tid}",
+            "languageNameInEnglish": f"Language {tid} EN",
+            "dialect": "",
+            "homeDomain": "",
+            "title": f"Title {tid}",
+            "description": "",
+            "Redistributable": "True",
+            "Copyright": "",
+            "UpdateDate": "2024-01-01",
+            "publicationURL": "",
+            "OTbooks": 0,
+            "OTchapters": 0,
+            "OTverses": 0,
+            "NTbooks": 1,
+            "NTchapters": 1,
+            "NTverses": 5,
+            "DCbooks": 0,
+            "DCchapters": 0,
+            "DCverses": 0,
+            "FCBHID": "",
+            "Certified": "",
+            "inScript": "True",
+            "swordName": "",
+            "rodCode": "",
+            "textDirection": "ltr",
+            "downloadable": "True",
+            "font": "",
+            "shortTitle": tid,
+            "PODISBN": "",
+            "script": "Latin",
+            "sourceDate": "2024-01-01",
+            "licence_Vernacular_Title": "",
+            "licence_Licence_Type": "Creative Commons",
+            "licence_Licence_Version": "4.0",
+            "licence_CC_Licence_Link": "https://creativecommons.org/licenses/by/4.0/",
+            "licence_Copyright_Holder": "Holder",
+            "licence_Copyright_Years": "2024",
+            "licence_Translation_by": "Org",
+            "status_inferred_versification": "4",
+            "status_extract_path": str(corpus_path),
+            "status_extract_date": "2024-01-01",
+            "status_extract_hash": "abc123",
+        }
+        if extra_cols:
+            row.update(extra_cols.get(tid, {}))
+        rows.append(row)
+
+    meta_dir = tmp_path / "metadata"
+    meta_dir.mkdir(exist_ok=True)
+    csv_path = meta_dir / "ebible_status.csv"
+    pd.DataFrame(rows).to_csv(csv_path, index=False)
+    return csv_path
+
+
+# ---------------------------------------------------------------------------
+# build_main_dataframe
+# ---------------------------------------------------------------------------
+
+def test_vref_is_first_column():
+    data = {"aaa-A": TRANS_A, "bbb-B": TRANS_B}
+    df = build_main_dataframe(VREF_5, data)
+    assert df.columns[0] == "vref"
+
+
+def test_translations_alphabetical():
+    data = {"zzz-Z": TRANS_B, "aaa-A": TRANS_A, "mmm-M": TRANS_C}
+    df = build_main_dataframe(VREF_5, data)
+    translation_cols = list(df.columns[1:])
+    assert translation_cols == sorted(translation_cols)
+
+
+def test_row_count():
+    data = {"aaa-A": TRANS_A}
+    df = build_main_dataframe(VREF_5, data)
+    assert len(df) == len(VREF_5)
+
+
+def test_empty_and_range_preserved(tmp_path):
+    data = {"aaa-A": TRANS_A}
+    df = build_main_dataframe(VREF_5, data)
+    # Row index 1: second line of TRANS_A is "<range>"
+    assert df.iloc[1]["aaa-A"] == "<range>"
+    # Row index 3: fourth line is ""
+    assert df.iloc[3]["aaa-A"] == ""
+
+
+def test_vref_values():
+    data = {"aaa-A": TRANS_A}
+    df = build_main_dataframe(VREF_5, data)
+    assert list(df["vref"]) == VREF_5
+
+
+# ---------------------------------------------------------------------------
+# build_metadata_dataframe
+# ---------------------------------------------------------------------------
+
+def _make_full_meta(included_ids):
+    rows = []
+    for tid in included_ids + ["excluded-X"]:
+        rows.append({
+            "translationId": tid,
+            "languageCode": tid[:3],
+            "status_inferred_versification": "4",
+            "licence_Licence_Type": "CC",
+        })
+    return pd.DataFrame(rows)
+
+
+def test_metadata_only_included_translations():
+    full = _make_full_meta(["aaa-A", "bbb-B"])
+    meta = build_metadata_dataframe(full, ["aaa-A", "bbb-B"])
+    assert set(meta["translationId"]) == {"aaa-A", "bbb-B"}
+    assert "excluded-X" not in meta["translationId"].values
+
+
+def test_inferred_versification_renamed():
+    full = _make_full_meta(["aaa-A"])
+    meta = build_metadata_dataframe(full, ["aaa-A"])
+    assert "inferred_versification" in meta.columns
+    assert "status_inferred_versification" not in meta.columns
+
+
+def test_metadata_absent_columns_skipped():
+    """Columns in METADATA_SOURCE_COLUMNS absent from the CSV are silently skipped."""
+    full = pd.DataFrame([{"translationId": "aaa-A", "languageCode": "aaa",
+                          "status_inferred_versification": "4"}])
+    meta = build_metadata_dataframe(full, ["aaa-A"])
+    assert "translationId" in meta.columns
+    assert "languageCode" in meta.columns
+    # Columns not present in source are absent (no KeyError)
+    assert "OTbooks" not in meta.columns
+
+
+# ---------------------------------------------------------------------------
+# render_readme
+# ---------------------------------------------------------------------------
+
+def test_readme_placeholders_replaced():
+    template = "Count: {{TRANSLATION_COUNT}} Date: {{GENERATED_DATE}}"
+    result = render_readme(template, {"TRANSLATION_COUNT": 42, "GENERATED_DATE": "2024-01-01"})
+    assert "{{" not in result
+    assert "42" in result
+    assert "2024-01-01" in result
+
+
+def test_readme_translation_count():
+    template = "Translations: {{TRANSLATION_COUNT}}"
+    result = render_readme(template, {"TRANSLATION_COUNT": 123})
+    assert "123" in result
+
+
+def test_readme_all_placeholders_replaced():
+    template_path = Path(__file__).parent.parent / "assets" / "README_template.md"
+    if not template_path.exists():
+        pytest.skip("README template not found")
+    template = template_path.read_text(encoding="utf-8")
+    result = render_readme(template, {
+        "TRANSLATION_COUNT": 10,
+        "LANGUAGE_COUNT": 5,
+        "VERSE_COUNT": VREF_LENGTH,
+        "GENERATED_DATE": "2024-01-01",
+        "GENERATED_YEAR": 2024,
+        "LICENCE_TABLE": "| id | type |\n|---|---|\n| aaa | CC |",
+    })
+    assert "{{" not in result
+
+
+# ---------------------------------------------------------------------------
+# validate_corpus_files (file-system tests using tmp_path)
+# ---------------------------------------------------------------------------
+
+def _make_candidates(corpus_paths: dict) -> pd.DataFrame:
+    rows = [{"translationId": tid, "status_extract_path": str(p)}
+            for tid, p in corpus_paths.items()]
+    return pd.DataFrame(rows)
+
+
+def test_valid_files_pass(tmp_path):
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    p = corpus_dir / "aaa-A.txt"
+    p.write_text("\n".join(["line"] * VREF_LENGTH) + "\n", encoding="utf-8")
+    candidates = _make_candidates({"aaa-A": p})
+    valid, skipped = validate_corpus_files(candidates, tmp_path, VREF_LENGTH, _input=lambda _: "y")
+    assert "aaa-A" in valid
+    assert skipped == []
+
+
+def test_missing_file_skipped(tmp_path):
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    missing = corpus_dir / "missing.txt"
+    candidates = _make_candidates({"missing-X": missing})
+    valid, skipped = validate_corpus_files(candidates, tmp_path, VREF_LENGTH, _input=lambda _: "y")
+    assert valid == []
+    assert "missing-X" in skipped
+
+
+def test_wrong_line_count_skipped(tmp_path):
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    p = corpus_dir / "bad-B.txt"
+    p.write_text("\n".join(["line"] * 100) + "\n", encoding="utf-8")
+    candidates = _make_candidates({"bad-B": p})
+    valid, skipped = validate_corpus_files(candidates, tmp_path, VREF_LENGTH, _input=lambda _: "y")
+    assert valid == []
+    assert "bad-B" in skipped
+
+
+def test_user_abort_on_issues(tmp_path):
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    missing = corpus_dir / "gone.txt"
+    candidates = _make_candidates({"gone-X": missing})
+    with pytest.raises(SystemExit):
+        validate_corpus_files(candidates, tmp_path, VREF_LENGTH, _input=lambda _: "n")
+
+
+def test_clean_range_called_in_validation(tmp_path):
+    """Orphaned <range> markers in an existing file are cleaned during validation."""
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    p = corpus_dir / "aaa-A.txt"
+    lines = [""] + ["<range>"] + ["line"] * (VREF_LENGTH - 2)
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    candidates = _make_candidates({"aaa-A": p})
+    validate_corpus_files(candidates, tmp_path, VREF_LENGTH, _input=lambda _: "y")
+    result = [line.rstrip("\r\n") for line in p.read_text(encoding="utf-8").splitlines()]
+    assert result[1] == ""  # orphaned <range> was cleaned
+
+
+# ---------------------------------------------------------------------------
+# Integration: output files are overwritten and contain correct data
+# ---------------------------------------------------------------------------
+
+def test_output_overwritten(tmp_path):
+    """Re-running build_main_dataframe with different data produces a different result."""
+    df1 = build_main_dataframe(VREF_5, {"aaa-A": TRANS_A})
+    df2 = build_main_dataframe(VREF_5, {"aaa-A": TRANS_B})
+    assert not df1.equals(df2)
+
+
+def test_metadata_columns_order(tmp_path):
+    """Columns in metadata output follow METADATA_SOURCE_COLUMNS order (renamed)."""
+    rows = [{c: "val" for c in METADATA_SOURCE_COLUMNS}]
+    rows[0]["translationId"] = "aaa-A"
+    full = pd.DataFrame(rows)
+    meta = build_metadata_dataframe(full, ["aaa-A"])
+    expected_cols = [
+        "inferred_versification" if c == "status_inferred_versification" else c
+        for c in METADATA_SOURCE_COLUMNS
+    ]
+    assert list(meta.columns) == expected_cols
+
+
+def test_load_and_filter_metadata_excludes_private(tmp_path):
+    meta_dir = tmp_path / "metadata"
+    meta_dir.mkdir()
+    csv_path = meta_dir / "ebible_status.csv"
+    rows = [
+        {"translationId": "pub-A", "Redistributable": "True",
+         "status_extract_path": "/corpus/pub-A.txt",
+         "status_extract_date": "2024-01-01", "status_extract_hash": "abc"},
+        {"translationId": "prv-B", "Redistributable": "True",
+         "status_extract_path": "/private_corpus/prv-B.txt",
+         "status_extract_date": "2024-01-01", "status_extract_hash": "def"},
+        {"translationId": "notredist-C", "Redistributable": "False",
+         "status_extract_path": "/corpus/notredist-C.txt",
+         "status_extract_date": "2024-01-01", "status_extract_hash": "ghi"},
+    ]
+    pd.DataFrame(rows).to_csv(csv_path, index=False)
+    result = load_and_filter_metadata(csv_path)
+    assert list(result["translationId"]) == ["pub-A"]


### PR DESCRIPTION
  Phase 1 — clean_range_markers in ebible.py
  - New function at ebible.py:241 — top-to-bottom pass replacing orphaned <range> markers with "", idempotent, returns replacement count
  - Called in extract_and_finalize_texts immediately after extraction (before hashing)
  - 9 tests in tests/test_clean_range_markers.py, all passing

  Phase 2 — assets/README_template.md
  - HuggingFace dataset card template with YAML frontmatter, all 5 placeholders ({{TRANSLATION_COUNT}}, {{LANGUAGE_COUNT}}, {{VERSE_COUNT}}, {{GENERATED_DATE}}, {{GENERATED_YEAR}}, {{LICENCE_TABLE}})

  Phase 3 — Full rewrite of corpus_to_parquet.py
  - argparse with --help listing all .env variables
  - Pre-flight validation pass: runs clean_range_markers (backfill), checks file existence and line count, reports all issues and prompts before skipping
  - main.parquet: vref as first column, translations alphabetical
  - metadata.parquet: all 33 original columns + 7 licence columns + inferred_versification (renamed), Parquet format, only included translations
  - README.md generated from template with injected stats
  - Bug fixes: removed phantom status_versification column, fixed metadata being written to wrong path as CSV

  Phase 4 — 19 tests in tests/test_parquet.py, all passing

  Details of work are in parquet/ folder.